### PR TITLE
remove internal mindmap zoom as the browser can be used for that

### DIFF
--- a/teammapper-frontend/src/app/core/services/shortcuts/shortcuts.service.ts
+++ b/teammapper-frontend/src/app/core/services/shortcuts/shortcuts.service.ts
@@ -74,18 +74,6 @@ export class ShortcutsService {
         this.mmpService.pasteNode()
       }
     }, {
-      keys: 'ctrl+=',
-      description: 'TOOLTIPS.ZOOM_IN_MAP',
-      callback: () => {
-        this.mmpService.zoomIn()
-      }
-    }, {
-      keys: 'ctrl+-',
-      description: 'TOOLTIPS.ZOOM_OUT_MAP',
-      callback: () => {
-        this.mmpService.zoomOut()
-      }
-    }, {
       keys: 'left',
       description: 'TOOLTIPS.SELECT_NODE_ON_THE_LEFT',
       callback: () => {

--- a/teammapper-frontend/src/app/modules/application/components/floating-buttons/floating-buttons.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/floating-buttons/floating-buttons.component.html
@@ -14,22 +14,6 @@
         </button>
     </div>
 
-    <div class="zoom-in no-touch">
-        <button (click)="mmpService.zoomIn()" [title]="'TOOLTIPS.ZOOM_IN_MAP' | translate"
-                class="mat-elevation-z2"
-                mat-mini-fab>
-            <mat-icon aria-label="Zoom in" color="primary">zoom_in</mat-icon>
-        </button>
-    </div>
-
-    <div class="zoom-out no-touch">
-        <button (click)="mmpService.zoomOut()" [title]="'TOOLTIPS.ZOOM_OUT_MAP' | translate"
-                class="mat-elevation-z2"
-                mat-mini-fab>
-            <mat-icon aria-label="Zoom out" color="primary">zoom_out</mat-icon>
-        </button>
-    </div>
-
     <div class="center no-touch">
         <button (click)="mmpService.center()" [title]="'TOOLTIPS.CENTER_MAP' | translate"
                 class="mat-elevation-z2"


### PR DESCRIPTION
closes #143 

This also saves some space because two buttons are no longer needed.

FYI: keyCodes of + AND = are identical, which means the keys can't be differentiated. Therefore, equal sign was shown in the hotkey list but it already was +. 