### PR TITLE
fix wrong return in handleDisconnect

### DIFF
--- a/teammapper-backend/src/map/controllers/maps.gateway.ts
+++ b/teammapper-backend/src/map/controllers/maps.gateway.ts
@@ -44,7 +44,7 @@ export class MapsGateway implements OnGatewayDisconnect {
   @SubscribeMessage('leave')
   async handleDisconnect(client: Socket) {
     const mapId: string | undefined = await this.cacheManager.get(client.id)
-    if(!mapId) return Promise.reject()
+    if(!mapId) return
 
     this.server.to(mapId).emit('clientDisconnect', client.id)
     this.removeClientForMap(mapId, client.id)


### PR DESCRIPTION
Fix wrong return as the method `handleDisconnect` does not return a promise.