### PR TITLE
Add additional checks to prevent WsExceptionHandler from throwing undefined errors

### DIFF
--- a/teammapper-backend/src/map/controllers/maps.gateway.ts
+++ b/teammapper-backend/src/map/controllers/maps.gateway.ts
@@ -125,7 +125,7 @@ export class MapsGateway implements OnGatewayDisconnect {
       request.mapId,
       request.nodes
     )
-    if (newNodes.length === 0) return false
+    if (!newNodes || newNodes.length === 0) return false
 
     this.server.to(request.mapId).emit('nodesAdded', {
       clientId: client.id,

--- a/teammapper-backend/src/map/services/maps.service.ts
+++ b/teammapper-backend/src/map/services/maps.service.ts
@@ -99,7 +99,7 @@ export class MapsService {
     mapId: string,
     nodes: Partial<MmpNode>[]
   ): Promise<MmpNode[]> {
-    if (!mapId || nodes.length === 0) Promise.reject()
+    if (!mapId || nodes.length === 0) return Promise.reject()
 
       const reducer = async (previousPromise: Promise<MmpNode[]>, node: MmpNode): Promise<MmpNode[]> => {
         const accCreatedNodes = await previousPromise;


### PR DESCRIPTION
closes #574

Previously, there was no check to see if newNodes actually existed, but since we're returning undefined, `newNodes.length` may actually throw an error.