### PR TITLE
Undoing import leads to wrong client state

### DIFF
--- a/teammapper-frontend/mmp/src/map/handlers/history.ts
+++ b/teammapper-frontend/mmp/src/map/handlers/history.ts
@@ -98,6 +98,7 @@ export default class History {
                 }
                 Log.error('There was an error importing the map; changes have been rolled back.')
             } else {
+                this.clearHistory()
                 this.save()
                 if (notifyWithEvent) this.map.events.call(Event.create, this.map.dom, { previousMap: previousData })
             }
@@ -152,6 +153,14 @@ export default class History {
         this.snapshots.push(this.getSnapshot())
 
         this.index++
+    }
+
+    /**
+     * Clears the history of the map
+     */
+    public clearHistory = () => {
+        this.snapshots = []
+        this.index = -1
     }
 
     /**

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
@@ -111,7 +111,7 @@
   <button
     (click)="mmpService.undo()"
     [title]="'TOOLTIPS.UNDO_MAP' | translate"
-    [disabled]="editDisabled"
+    [disabled]="editDisabled || !canUndoRedo"
     color="primary"
     mat-icon-button>
     <mat-icon>undo</mat-icon>
@@ -120,7 +120,7 @@
   <button
     (click)="mmpService.redo()"
     [title]="'TOOLTIPS.REDO_MAP' | translate"
-    [disabled]="editDisabled"
+    [disabled]="editDisabled || !canUndoRedo"
     color="primary"
     mat-icon-button>
     <mat-icon>redo</mat-icon>

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.spec.ts
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.spec.ts
@@ -6,7 +6,7 @@ import { ToolbarComponent } from './toolbar.component';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
-import { ExportNodeProperties, MapSnapshot } from '@mmp/map/types';
+import { ExportNodeProperties } from '@mmp/map/types';
 import { Font } from 'mmp/src/map/models/node';
 import { of } from 'rxjs';
 
@@ -22,7 +22,6 @@ describe('ToolbarComponent', () => {
       exportMap: jest.fn(),
       nodeChildren: jest.fn(),
       getSelectedNode: jest.fn(),
-      history: jest.fn(),
       selectNode: jest.fn(),
       updateNode: jest.fn(),
       addNodeLink: jest.fn(),
@@ -135,7 +134,7 @@ describe('ToolbarComponent', () => {
       expect(component.canHideNodes).toBeTruthy();
     });
   });
-  
+
   describe('font style toggle', () => {
     it('should toggle font style between italic and normal', () => {
       const mockFont: Font = {

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.spec.ts
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.spec.ts
@@ -6,7 +6,7 @@ import { ToolbarComponent } from './toolbar.component';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
-import { ExportNodeProperties } from '@mmp/map/types';
+import { ExportNodeProperties, MapSnapshot } from '@mmp/map/types';
 import { Font } from 'mmp/src/map/models/node';
 import { of } from 'rxjs';
 
@@ -22,6 +22,7 @@ describe('ToolbarComponent', () => {
       exportMap: jest.fn(),
       nodeChildren: jest.fn(),
       getSelectedNode: jest.fn(),
+      history: jest.fn(),
       selectNode: jest.fn(),
       updateNode: jest.fn(),
       addNodeLink: jest.fn(),
@@ -134,7 +135,7 @@ describe('ToolbarComponent', () => {
       expect(component.canHideNodes).toBeTruthy();
     });
   });
-
+  
   describe('font style toggle', () => {
     it('should toggle font style between italic and normal', () => {
       const mockFont: Font = {

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.ts
@@ -43,6 +43,13 @@ export class ToolbarComponent {
     }
   }
 
+  get canUndoRedo() {
+    if (this.mmpService) {
+      const history = this.mmpService.history();
+      return history.snapshots.length > 1
+    }
+  }
+
   public async share() {
     this.dialogService.openShareDialog();
   }

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.ts
@@ -19,7 +19,7 @@ export class ToolbarComponent {
     private translationService: TranslateService,
     public mmpService: MmpService,
     private dialogService: DialogService
-  ) { }
+  ) {}
 
   public async exportMap(format: string) {
     const result = await this.mmpService.exportMap(format);

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.ts
@@ -19,7 +19,7 @@ export class ToolbarComponent {
     private translationService: TranslateService,
     public mmpService: MmpService,
     private dialogService: DialogService
-  ) {}
+  ) { }
 
   public async exportMap(format: string) {
     const result = await this.mmpService.exportMap(format);
@@ -44,10 +44,11 @@ export class ToolbarComponent {
   }
 
   get canUndoRedo() {
-    if (this.mmpService) {
+    if (this.mmpService && typeof this.mmpService.history === 'function') {
       const history = this.mmpService.history();
-      return history.snapshots.length > 1
+      return history?.snapshots?.length > 1;
     }
+    return false;
   }
 
   public async share() {


### PR DESCRIPTION
closes #618 by preventing undo/redo on map import (clears snapshot history, disables undo/redo buttons)