### PR TITLE
Fix Routing

### DIFF
--- a/teammapper-backend/src/app.module.ts
+++ b/teammapper-backend/src/app.module.ts
@@ -3,12 +3,18 @@ import { ConfigModule } from '@nestjs/config'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import configService from './config.service'
 import { MapModule } from './map/map.module'
+import { ServeStaticModule } from '@nestjs/serve-static'
+import { join } from 'path'
 
 @Module({
   imports: [
     ConfigModule.forRoot(),
     TypeOrmModule.forRoot(configService.getTypeOrmConfig()),
     MapModule,
+    ServeStaticModule.forRoot({
+      rootPath: join(__dirname, '..', 'client', 'browser'),
+      exclude: ['/assets/'],
+    }),
   ],
 })
 export default class AppModule {}

--- a/teammapper-backend/src/main.ts
+++ b/teammapper-backend/src/main.ts
@@ -50,7 +50,6 @@ async function bootstrap() {
     })
   )
 
-  // Serve static assets first
   app.useStaticAssets(join(__dirname, '..', 'client/browser/assets'), {
     prefix: '/assets/',
     setHeaders: (res, path) => {
@@ -62,11 +61,6 @@ async function bootstrap() {
         res.setHeader('Cache-Control', 'public, max-age=86400')
       }
     },
-  })
-
-  // Serve Angular app files (js, css, html)
-  app.useStaticAssets(join(__dirname, '..', 'client/browser'), {
-    extensions: ['html', 'js', 'css'],
   })
 
   await app.listen(configService.getPort())


### PR DESCRIPTION
The changes to serve the static assets breaks the routing in some cases (e.g. when refreshing a map page or duplicating a map). To fix that, the app is served as a static module again. Static assets are still served by the same route as before.