### PR TITLE
add owner id migration

### DIFF
--- a/teammapper-backend/src/migrations/1765782220832-AddOwnerId.ts
+++ b/teammapper-backend/src/migrations/1765782220832-AddOwnerId.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddOwnerId1765782220832 implements MigrationInterface {
+    name = 'AddOwnerId1765782220832'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "mmp_map" ADD "ownerExternalId" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "mmp_map" DROP COLUMN "ownerExternalId"`);
+    }
+
+}


### PR DESCRIPTION
## Description

During the introduction of the owner id, the migration file was missed. closes #1099 