### PR TITLE
spec: yjs-introduction section 9

### DIFF
--- a/openspec/changes/yjs-introduction/tasks.md
+++ b/openspec/changes/yjs-introduction/tasks.md
@@ -158,10 +158,10 @@
 > **App state after merge**: Connections that stall during setup are closed after 10 seconds.
 > **PRODUCTION-BLOCKING**: Without this, slow DB responses hang connections indefinitely.
 
-- [ ] 9.1 Wrap async operations in `handleConnection` with `Promise.race` against a 10-second timeout using `AbortController`
-- [ ] 9.2 Close WebSocket with code 1013 on timeout; cancel timer on success/failure via `AbortController`
-- [ ] 9.3 Add unit tests: setup completes within timeout (normal), setup exceeds timeout (closed with 1013), timer canceled on early completion
-- [ ] 9.4 Run lint, test, format — verify app still works
+- [x] 9.1 Wrap async operations in `handleConnection` with `Promise.race` against a 10-second timeout using `AbortController`
+- [x] 9.2 Close WebSocket with code 1013 on timeout; cancel timer on success/failure via `AbortController`
+- [x] 9.3 Add unit tests: setup completes within timeout (normal), setup exceeds timeout (closed with 1013), timer canceled on early completion
+- [x] 9.4 Run lint, test, format — verify app still works
 
 ## 10. Persistence Shutdown and Async Close Fixes
 

--- a/teammapper-backend/src/map/utils/yjsProtocol.ts
+++ b/teammapper-backend/src/map/utils/yjsProtocol.ts
@@ -24,6 +24,12 @@ export const WS_MAX_PAYLOAD = 1_048_576
 // Heartbeat interval for zombie connection detection (ms)
 export const HEARTBEAT_INTERVAL_MS = 30_000
 
+// Connection setup timeout (ms) — slow DB responses close with 1013
+export const CONNECTION_SETUP_TIMEOUT_MS = 10_000
+
+// Standard WebSocket close code: Try Again Later (RFC 6455)
+export const WS_CLOSE_TRY_AGAIN = 1013
+
 export interface ConnectionMeta {
   mapId: string
   writable: boolean


### PR DESCRIPTION
- Add 10-second timeout on WebSocket connection setup to prevent connections from hanging indefinitely when the database is slow or unresponsive
- On timeout, the WebSocket is closed with code 1013 (Try Again Later) and the limiter slot is released
- Uses Promise.race with AbortController; signal checks after each await prevent double-release of limiter slots

Ref https://github.com/b310-digital/teammapper/issues/1164