### PR TITLE
spec: yjs-introduction section 10

### DIFF
--- a/openspec/changes/yjs-introduction/tasks.md
+++ b/openspec/changes/yjs-introduction/tasks.md
@@ -169,11 +169,11 @@
 > **App state after merge**: Clean shutdown with no orphaned timers, no silently swallowed errors.
 > **PRODUCTION-BLOCKING**: Without this, grace timer race can orphan Y.Docs in memory permanently.
 
-- [ ] 10.1 Implement `OnModuleDestroy` in `YjsPersistenceService`: clear all debounce timers, unregister observers, best-effort flush with 5-second timeout
-- [ ] 10.2 Add `.catch()` error handling on `decrementClientCount` call in `handleClose` to log persistence errors with mapId
-- [ ] 10.3 Add try/finally in `handleConnection` around `getOrCreateDoc` → `trackConnection` → `incrementClientCount` to restore grace timer on failure
-- [ ] 10.4 Add unit tests: persistence shutdown clears timers and flushes, decrement errors are logged not swallowed, grace timer restored on setup failure
-- [ ] 10.5 Run lint, test, format — verify app still works
+- [x] 10.1 Implement `OnModuleDestroy` in `YjsPersistenceService`: clear all debounce timers, unregister observers, best-effort flush with 5-second timeout
+- [x] 10.2 Add `.catch()` error handling on `decrementClientCount` call in `handleClose` to log persistence errors with mapId
+- [x] 10.3 Add try/finally in `handleConnection` around `getOrCreateDoc` → `trackConnection` → `incrementClientCount` to restore grace timer on failure
+- [x] 10.4 Add unit tests: persistence shutdown clears timers and flushes, decrement errors are logged not swallowed, grace timer restored on setup failure
+- [x] 10.5 Run lint, test, format — verify app still works
 
 ## 11. Unified Client Count Tracking
 

--- a/teammapper-backend/src/map/services/yjs-doc-manager.service.ts
+++ b/teammapper-backend/src/map/services/yjs-doc-manager.service.ts
@@ -81,6 +81,14 @@ export class YjsDocManagerService implements OnModuleDestroy {
     this.forceDestroyDoc(mapId)
   }
 
+  // Restores the grace timer if no clients are connected (used on setup failure)
+  restoreGraceTimer(mapId: string): void {
+    const entry = this.docs.get(mapId)
+    if (!entry || entry.clientCount > 0) return
+
+    this.startGraceTimer(mapId, entry)
+  }
+
   hasDoc(mapId: string): boolean {
     return this.docs.has(mapId)
   }


### PR DESCRIPTION
Fixes persistence service shutdown lifecycle, async error handling in the WebSocket close handler, and a grace timer race condition in the Yjs gateway. These are fixes that prevent orphaned Y.Docs from accumulating in memory permanently.

Three targeted fixes:

- Graceful persistence shutdown: YjsPersistenceService now implements OnModuleDestroy to clear all debounce timers, unregister doc update observers, and best-effort flush pending writes with a 5-second timeout. Previously, active debounce timers could fire after the database connection was closed.
- Async error handling in close handler: The decrementClientCount call in handleClose was fire-and-forget with no error handling. Database errors during client disconnect were silently swallowed. Now caught with .catch() and logged with mapId context.
- Grace timer race condition prevention: If handleConnection failed after getOrCreateDoc (which cancels the grace timer) but before incrementClientCount, the Y.Doc would be stuck in memory with no grace timer and no clients -- permanently orphaned. A try/finally block now restores the grace timer on setup failure. Added restoreGraceTimer() to YjsDocManagerService to support this.

Ref https://github.com/b310-digital/teammapper/issues/1164

