### PR TITLE
spec: yjs-introduction section 11+12

### DIFF
--- a/openspec/changes/yjs-introduction/tasks.md
+++ b/openspec/changes/yjs-introduction/tasks.md
@@ -181,13 +181,13 @@
 > **App state after merge**: Client count always matches actual connection count — no drift possible.
 > **PRODUCTION-BLOCKING**: Without this, client count drift can cause premature or delayed Y.Doc eviction.
 
-- [ ] 11.1 Remove `clientCount` field from `DocEntry` in `yjs-doc-manager.service.ts`
-- [ ] 11.2 Replace `incrementClientCount` / `decrementClientCount` with a `notifyClientCount(mapId: string, count: number)` method that accepts the count from the gateway
-- [ ] 11.3 Update gateway's `handleClose` to pass `mapConnections.get(mapId)?.size ?? 0` to doc manager after removing the connection
-- [ ] 11.4 Update gateway's `handleConnection` to pass connection count after `trackConnection`
-- [ ] 11.5 Update `getClientCount` to accept count from gateway or return 0 if doc not tracked
-- [ ] 11.6 Update existing unit tests in `yjs-doc-manager.service.spec.ts` and `yjs-gateway.service.spec.ts` for the new interface
-- [ ] 11.7 Run lint, test, format — verify app still works
+- [x] 11.1 Remove `clientCount` field from `DocEntry` in `yjs-doc-manager.service.ts`
+- [x] 11.2 Replace `incrementClientCount` / `decrementClientCount` with a `notifyClientCount(mapId: string, count: number)` method that accepts the count from the gateway
+- [x] 11.3 Update gateway's `handleClose` to pass `mapConnections.get(mapId)?.size ?? 0` to doc manager after removing the connection
+- [x] 11.4 Update gateway's `handleConnection` to pass connection count after `trackConnection`
+- [x] 11.5 Update `getClientCount` to accept count from gateway or return 0 if doc not tracked
+- [x] 11.6 Update existing unit tests in `yjs-doc-manager.service.spec.ts` and `yjs-gateway.service.spec.ts` for the new interface
+- [x] 11.7 Run lint, test, format — verify app still works
 
 ## 12. Async deleteMap
 
@@ -195,11 +195,11 @@
 > **App state after merge**: Map deletion errors properly propagate to callers.
 > **PRODUCTION-BLOCKING**: Without this, deletion errors are silently swallowed and callers respond before delete completes.
 
-- [ ] 12.1 Change `deleteMap` in `maps.service.ts` to `async deleteMap(uuid: string): Promise<void>` with `await` on the repository delete
-- [ ] 12.2 Update `maps.controller.ts` to `await this.mapsService.deleteMap(mapId)`
-- [ ] 12.3 Update `maps.gateway.ts` to `await this.mapsService.deleteMap(request.mapId)`
-- [ ] 12.4 Update `maps.controller.spec.ts` mock to return a resolved promise
-- [ ] 12.5 Run lint, test, format — verify app still works
+- [x] 12.1 Change `deleteMap` in `maps.service.ts` to `async deleteMap(uuid: string): Promise<void>` with `await` on the repository delete
+- [x] 12.2 Update `maps.controller.ts` to `await this.mapsService.deleteMap(mapId)`
+- [x] 12.3 Update `maps.gateway.ts` to `await this.mapsService.deleteMap(request.mapId)`
+- [x] 12.4 Update `maps.controller.spec.ts` mock to return a resolved promise
+- [x] 12.5 Run lint, test, format — verify app still works
 
 ## 13. Cleanup: Remove Socket.io & Dead Code
 

--- a/teammapper-backend/src/map/controllers/maps.controller.spec.ts
+++ b/teammapper-backend/src/map/controllers/maps.controller.spec.ts
@@ -152,7 +152,7 @@ describe('MapsController', () => {
 
       jest.spyOn(mapsService, 'findMap').mockResolvedValueOnce(existingMap)
       // We're not interested in testing the repository at this stage, only if the request gets past the admin ID check
-      jest.spyOn(mapsService, 'deleteMap').mockImplementation(() => {})
+      jest.spyOn(mapsService, 'deleteMap').mockResolvedValue(undefined)
 
       await mapsController.delete(existingMap.id, {
         adminId: existingMap.adminId,

--- a/teammapper-backend/src/map/controllers/maps.controller.ts
+++ b/teammapper-backend/src/map/controllers/maps.controller.ts
@@ -71,7 +71,7 @@ export default class MapsController {
         this.yjsGateway.closeConnectionsForMap(mapId)
         this.yjsDocManager.destroyDoc(mapId)
       }
-      this.mapsService.deleteMap(mapId)
+      await this.mapsService.deleteMap(mapId)
     }
   }
 

--- a/teammapper-backend/src/map/controllers/maps.gateway.ts
+++ b/teammapper-backend/src/map/controllers/maps.gateway.ts
@@ -143,7 +143,7 @@ export class MapsGateway implements OnGatewayDisconnect {
         request.mapId
       )
       if (mmpMap && mmpMap.adminId === request.adminId) {
-        this.mapsService.deleteMap(request.mapId)
+        await this.mapsService.deleteMap(request.mapId)
         this.server.to(request.mapId).emit('mapDeleted')
         return true
       }

--- a/teammapper-backend/src/map/services/maps.service.ts
+++ b/teammapper-backend/src/map/services/maps.service.ts
@@ -1036,8 +1036,8 @@ export class MapsService {
     return 0
   }
 
-  deleteMap(uuid: string) {
-    this.mapsRepository.delete({ id: uuid })
+  async deleteMap(uuid: string): Promise<void> {
+    await this.mapsRepository.delete({ id: uuid })
   }
 
   async validatesNodeParentForNode(


### PR DESCRIPTION
Replaces the internal clientCount tracking in YjsDocManagerService with a gateway-driven notifyClientCount approach, and makes deleteMap properly async.                                                                                                                      
                  
  Motivation:
- The doc manager previously maintained its own clientCount field that could drift out of sync with actual WebSocket connections tracked by the gateway, potentially causing premature or delayed Y.Doc eviction in production
- deleteMap was fire-and-forget, silently swallowing database errors

 Changes:
- Removed clientCount field from DocEntry; replaced incrementClientCount/decrementClientCount with a single notifyClientCount(mapId, count) method that receives the authoritative count from the gateway
- Updated restoreGraceTimer to accept a connectionCount parameter so it can skip timer restoration when connections still exist
- Made deleteMap in MapsService properly async with await on the repository call
- Updated callers in MapsController and MapsGateway to await the delete
- Updated all unit tests to match the new interfaces

Ref https://github.com/b310-digital/teammapper/issues/1164