### PR TITLE
fix: explicitly enable user selection on node edit for mobile devices

### DIFF
--- a/teammapper-frontend/e2e/node-editing.spec.ts
+++ b/teammapper-frontend/e2e/node-editing.spec.ts
@@ -91,6 +91,9 @@ test('adds a node and drags it - screenshot test', async ({ page }) => {
   );
   await page.mouse.up();
 
+  // Wait for dragging to finish
+  await page.waitForTimeout(500);
+
   // Take a screenshot of the map after dragging
   await expect(page.locator('.map')).toHaveScreenshot('node-after-drag.png', {
     timeout: 500,

--- a/teammapper-frontend/mmp/src/map/handlers/draw.ts
+++ b/teammapper-frontend/mmp/src/map/handlers/draw.ts
@@ -417,6 +417,8 @@ export default class Draw {
     Utils.focusWithCaretAtEnd(name);
 
     name.style.setProperty('cursor', 'auto');
+    name.style.setProperty('user-select', 'text');
+    name.style.setProperty('-webkit-user-select', 'text');
 
     this.updateNodeShapes(node);
 
@@ -491,6 +493,8 @@ export default class Draw {
 
       name.setAttribute('contenteditable', 'false');
       name.style.setProperty('cursor', 'pointer');
+      name.style.removeProperty('user-select');
+      name.style.removeProperty('-webkit-user-select');
 
       name.blur();
     };


### PR DESCRIPTION
Fixes an issue where mobile devices like Android and iOS cannot modify text inside nodes after they are created. 

Explicitly setting `user-select` and `-webkit-user-select` to `text` for the node's DOM element while editing enables proper text selection and interaction on touch devices. These explicit styles are reverted back on blur to ensure they don't impact interactions with the node when not editing.

---
*PR created automatically by Jules for task [2910394211560188511](https://jules.google.com/task/2910394211560188511) started by @JannikStreek*