### PR TITLE
Skip map re-centering while editing to fix mobile keyboard flicker

### DIFF
--- a/teammapper-frontend/mmp/src/map/map.ts
+++ b/teammapper-frontend/mmp/src/map/map.ts
@@ -1,4 +1,5 @@
 import * as d3 from 'd3';
+import Utils from '../utils/utils';
 import Events from './handlers/events';
 import Zoom from './handlers/zoom';
 import Draw from './handlers/draw';
@@ -55,6 +56,10 @@ export default class MmpMap {
 
     if (this.options.centerOnResize === true) {
       d3.select(window).on('resize.' + this.id, () => {
+        // On mobile, opening the soft keyboard fires a window resize.
+        // Re-centering would translate the SVG, move the focused node,
+        // and make the keyboard flicker or fail to stay open.
+        if (Utils.isEditingActiveElement()) return;
         this.zoom.center();
       });
     }

--- a/teammapper-frontend/mmp/src/map/options.ts
+++ b/teammapper-frontend/mmp/src/map/options.ts
@@ -118,6 +118,10 @@ export default class Options implements OptionParameters {
 
     if (this.centerOnResize === true) {
       d3.select(window).on('resize.' + this.map.id, () => {
+        // Skip re-centering while editing, otherwise the mobile soft
+        // keyboard resize would move the focused node and make the
+        // keyboard flicker or fail to stay open.
+        if (Utils.isEditingActiveElement()) return;
         this.map.zoom.center();
       });
     } else {

--- a/teammapper-frontend/mmp/src/utils/utils.ts
+++ b/teammapper-frontend/mmp/src/utils/utils.ts
@@ -173,6 +173,15 @@ export default class Utils {
   }
 
   /**
+   * Return true if the currently focused element is a contenteditable
+   * node being actively edited.
+   */
+  static isEditingActiveElement(): boolean {
+    const active = document.activeElement as HTMLElement | null;
+    return !!active && active.isContentEditable;
+  }
+
+  /**
    * Gets the nested property of object
    * @param obj
    * @param path


### PR DESCRIPTION
On mobile, opening the soft keyboard fires a window resize event. The centerOnResize handler would then animate the SVG back to center, moving the focused node out from under the caret and causing the keyboard to flicker or fail to stay open — making node editing unusable on Android Chrome and iOS Safari (issue #1249).

https://claude.ai/code/session_01KvjsNvZKoJcL9k3cTCuTNu