### PR TITLE
feat: Lay out imported maps from the tree instead of from siblings

### DIFF
--- a/teammapper-frontend/mmp/src/map/handlers/apply-coordinates.spec.ts
+++ b/teammapper-frontend/mmp/src/map/handlers/apply-coordinates.spec.ts
@@ -1,0 +1,95 @@
+import Nodes from './nodes';
+import MmpMap from '../map';
+import { Coordinates, ExportNodeProperties } from '../models/node';
+
+/**
+ * Snapshots here are shaped the way an import delivers them: the root has
+ * `parent: ''` and `isRoot: true`, and a node without a saved position has no
+ * `coordinates` key at all.
+ */
+
+function createHandler(): Nodes {
+  // No live map needed: the snapshot's nodes do not exist yet, so everything is
+  // derived from the snapshot itself.
+  return new Nodes({} as unknown as MmpMap);
+}
+
+function makeNode(
+  id: string,
+  parent: string,
+  options: { isRoot?: boolean; coordinates?: Coordinates } = {}
+): ExportNodeProperties {
+  return {
+    id,
+    parent,
+    k: 1,
+    isRoot: options.isRoot ?? false,
+    detached: false,
+    ...(options.coordinates ? { coordinates: options.coordinates } : {}),
+  };
+}
+
+/** The largest shape the AI import prompt produces: 4 topics x 3 subtopics. */
+function buildAiShapeSnapshot(): ExportNodeProperties[] {
+  const snapshot: ExportNodeProperties[] = [
+    makeNode('root', '', { isRoot: true }),
+  ];
+
+  ['A', 'B', 'C', 'D'].forEach(branch => {
+    snapshot.push(makeNode(branch, 'root'));
+    for (let i = 1; i <= 3; i++) {
+      snapshot.push(makeNode(`${branch}${i}`, branch));
+    }
+  });
+
+  return snapshot;
+}
+
+describe('applyCoordinatesToMapSnapshot', () => {
+  it('hands back the very same array when there is nothing to position', () => {
+    const handler = createHandler();
+    const snapshot = [
+      makeNode('root', '', { isRoot: true, coordinates: { x: 0, y: 0 } }),
+      makeNode('left', 'root', { coordinates: { x: -200, y: 60 } }),
+      makeNode('right', 'root', { coordinates: { x: 200, y: 60 } }),
+    ];
+
+    const result = handler.applyCoordinatesToMapSnapshot(snapshot);
+
+    // Identity, not equality: a fully-positioned snapshot skips the layout
+    // altogether instead of rebuilding an equal array.
+    expect(result).toBe(snapshot);
+  });
+
+  it('preserves already-positioned nodes and assigns positions only to the rest', () => {
+    const handler = createHandler();
+    const preservedCoordinates: Coordinates = { x: 600, y: 60 };
+    const snapshot = [
+      makeNode('root', '', { isRoot: true, coordinates: { x: 0, y: 0 } }),
+      makeNode('positioned', 'root', { coordinates: preservedCoordinates }),
+      makeNode('coordinateLess', 'root'),
+    ];
+
+    const result = handler.applyCoordinatesToMapSnapshot(snapshot);
+
+    expect(result.find(node => node.id === 'positioned')?.coordinates).toBe(
+      preservedCoordinates
+    );
+    expect(
+      result.find(node => node.id === 'coordinateLess')?.coordinates
+    ).toBeDefined();
+  });
+
+  it('assigns finite coordinates to every node of a coordinate-less import', () => {
+    const handler = createHandler();
+
+    const result = handler.applyCoordinatesToMapSnapshot(
+      buildAiShapeSnapshot()
+    );
+
+    result.forEach(node => {
+      expect(Number.isFinite(node.coordinates?.x)).toBe(true);
+      expect(Number.isFinite(node.coordinates?.y)).toBe(true);
+    });
+  });
+});

--- a/teammapper-frontend/mmp/src/map/handlers/nodes.ts
+++ b/teammapper-frontend/mmp/src/map/handlers/nodes.ts
@@ -16,6 +16,7 @@ import { Event } from './events';
 import Log from '../../utils/log';
 import Utils from '../../utils/utils';
 import { MapSnapshot } from './history';
+import { computeMapLayout } from './layout';
 import { NODE_HORIZONTAL_SPACING } from './node-geometry';
 
 const NODE_VERTICAL_SIBLING_OFFSET = 60; // The y-axis spacing between sibling nodes
@@ -842,34 +843,26 @@ export default class Nodes {
     });
   }
 
+  /**
+   * Position the snapshot nodes that arrive without coordinates - every node of
+   * an AI or mermaid import, which carry structure only. A node that already
+   * has coordinates keeps them, so re-importing an exported map moves nothing.
+   *
+   * `calculateNodeCoordinates` cannot do this job: it reads siblings that have
+   * not been positioned yet, so it superimposes whole branches on a bulk
+   * import.
+   */
   public applyCoordinatesToMapSnapshot = (
     mapSnapshot: MapSnapshot
   ): MapSnapshot => {
-    const rootNode = mapSnapshot.find(x => x.isRoot);
+    if (mapSnapshot.every(node => !!node.coordinates)) return mapSnapshot;
+
+    const layout = computeMapLayout(mapSnapshot);
 
     return mapSnapshot.map(node => {
-      if (!node.coordinates) {
-        /**
-         * Since we're working with a JSON snapshot here, none of the nodes actually exist.
-         * This makes existing methods such as this.getSiblings() useless, because they only work with existing nodes.
-         * So here, we pass on methods that work directly with the JSON.
-         */
-        node.coordinates = this.calculateNodeCoordinates(node, {
-          nodeParent: node.parent
-            ? mapSnapshot.find(x => x.id === node.parent)
-            : null,
-          getSiblings: () =>
-            node.parent
-              ? mapSnapshot.filter(
-                  x => x.parent === node.parent && x.id !== node.id
-                )
-              : [],
-          isRoot:
-            !!node.parent &&
-            mapSnapshot.find(x => x.id === node.parent)?.isRoot,
-          getOrientation: (n: ExportNodeProperties) =>
-            this.getOrientation(n, rootNode),
-        });
+      const position = layout.get(node.id);
+      if (!node.coordinates && position) {
+        node.coordinates = { x: position.x, y: position.y };
       }
 
       return node;


### PR DESCRIPTION
An AI or mermaid import carries no coordinates, and deriving each position from siblings that have not been positioned yet superimposed whole branches; hand the snapshot to computeMapLayout instead.