### PR TITLE
feat: Add a toolbar action to redistribute an existing map

### DIFF
--- a/teammapper-frontend/mmp/src/map/handlers/distribute-nodes.spec.ts
+++ b/teammapper-frontend/mmp/src/map/handlers/distribute-nodes.spec.ts
@@ -1,0 +1,202 @@
+import * as d3 from 'd3';
+import Nodes from './nodes';
+import Node from '../models/node';
+import MmpMap from '../map';
+import { Event } from './events';
+
+interface StubMap {
+  id: string;
+  draw: { update: jest.Mock; drawBranch: jest.Mock };
+  history: { save: jest.Mock };
+  events: { call: jest.Mock };
+}
+
+function stubMap(): StubMap {
+  return {
+    id: 'test-map',
+    draw: {
+      update: jest.fn(),
+      // The real `drawBranch` returns nothing for a node without a parent.
+      drawBranch: jest.fn((node: Node) => (node.parent ? 'M0,0' : undefined)),
+    },
+    history: { save: jest.fn() },
+    events: { call: jest.fn() },
+  };
+}
+
+/** Branch paths the way `draw.update()` binds them: one per node but the root. */
+function attachBranchPaths(mapId: string, nodes: Node[]): void {
+  d3.select(document.body)
+    .append('svg')
+    .selectAll('path')
+    .data<Node>(nodes.slice(1))
+    .enter()
+    .append('path')
+    .attr('class', `${mapId}_branch`)
+    .attr('id', node => `${node.id}_branch`);
+}
+
+/** Only the fields distribution reads, hence the cast. */
+function liveNode(
+  id: string,
+  parent: Node | null,
+  overrides: Partial<Node> = {}
+): Node {
+  return {
+    id,
+    parent,
+    name: id,
+    isRoot: false,
+    detached: false,
+    hidden: false,
+    coordinates: { x: 0, y: 0 },
+    dimensions: { width: 100, height: 30 },
+    ...overrides,
+  } as unknown as Node;
+}
+
+interface NodesInternals {
+  nodes: Map<string, Node>;
+}
+
+function handlerWith(nodes: Node[]): { handler: Nodes; map: StubMap } {
+  const map = stubMap();
+  const handler = new Nodes(map as unknown as MmpMap);
+  (handler as unknown as NodesInternals).nodes = new Map(
+    nodes.map(node => [node.id, node])
+  );
+
+  return { handler, map };
+}
+
+/** Root with four branches of three children: the shape an AI import makes. */
+function aiShapedNodes(): Node[] {
+  const root = liveNode('root', null, { isRoot: true });
+  const nodes: Node[] = [root];
+
+  for (const branch of ['A', 'B', 'C', 'D']) {
+    const branchNode = liveNode(branch, root);
+    nodes.push(branchNode);
+    for (let i = 1; i <= 3; i++) {
+      nodes.push(liveNode(`${branch}${i}`, branchNode));
+    }
+  }
+  return nodes;
+}
+
+describe('distributeNodes', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('writes new coordinates onto the live nodes', () => {
+    const nodes = aiShapedNodes();
+    const { handler } = handlerWith(nodes);
+    const before = nodes.map(node => ({ ...node.coordinates }));
+
+    handler.distributeNodes();
+
+    const moved = nodes.filter(
+      (node, i) =>
+        node.coordinates.x !== before[i].x || node.coordinates.y !== before[i].y
+    );
+    expect(moved.length).toBeGreaterThan(0);
+  });
+
+  it('hands the hidden nodes to the layout too, so they keep their room', () => {
+    // A collapsed branch is still laid out, so expanding it again does not
+    // leave its children piled up.
+    const root = liveNode('root', null, { isRoot: true });
+    const collapsed = liveNode('collapsed', root);
+    const nodes = [root, collapsed];
+    for (let i = 1; i <= 4; i++) {
+      nodes.push(liveNode(`c${i}`, collapsed, { hidden: true }));
+    }
+    const { handler } = handlerWith(nodes);
+
+    handler.distributeNodes();
+
+    // Filtered out of the layout input they would all keep y: 0.
+    const hiddenYs = nodes
+      .filter(node => node.hidden)
+      .map(node => node.coordinates.y);
+    expect(new Set(hiddenYs).size).toBe(4);
+  });
+
+  it('updates the transform of a node that has been drawn', () => {
+    const root = liveNode('root', null, { isRoot: true });
+    const setAttribute = jest.fn();
+    const child = liveNode('child', root, {
+      dom: { setAttribute } as unknown as SVGGElement,
+    });
+    const { handler } = handlerWith([root, child]);
+
+    handler.distributeNodes();
+
+    expect(setAttribute).toHaveBeenCalledWith(
+      'transform',
+      expect.stringContaining('translate(')
+    );
+  });
+
+  it('records the whole redistribution as a single history entry', () => {
+    const { handler, map } = handlerWith(aiShapedNodes());
+
+    handler.distributeNodes();
+
+    expect(map.history.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('redraws the map once rather than once per node', () => {
+    const { handler, map } = handlerWith(aiShapedNodes());
+
+    handler.distributeNodes();
+
+    expect(map.draw.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits a distribute event so the sync layer can propagate the rewrite', () => {
+    const { handler, map } = handlerWith(aiShapedNodes());
+
+    handler.distributeNodes();
+
+    const events = map.events.call.mock.calls.map(call => call[0]);
+    expect(events).toContain(Event.distribute);
+  });
+
+  it('does not emit the distribute event when notification is suppressed', () => {
+    const { handler, map } = handlerWith(aiShapedNodes());
+
+    handler.distributeNodes(false);
+
+    const events = map.events.call.mock.calls.map(call => call[0]);
+    expect(events).not.toContain(Event.distribute);
+  });
+
+  it('redraws every branch, dropping the path of a detached node', () => {
+    const root = liveNode('root', null, { isRoot: true });
+    const child = liveNode('child', root);
+    const loose = liveNode('loose', null, { detached: true });
+    const nodes = [root, child, loose];
+    const { handler, map } = handlerWith(nodes);
+    attachBranchPaths(map.id, nodes);
+
+    handler.distributeNodes();
+
+    expect(document.getElementById('child_branch')?.getAttribute('d')).toBe(
+      'M0,0'
+    );
+    // Nothing to draw for a parentless node, so the attribute is dropped.
+    expect(
+      document.getElementById('loose_branch')?.getAttribute('d')
+    ).toBeNull();
+  });
+
+  it('leaves an empty map alone', () => {
+    const { handler, map } = handlerWith([]);
+
+    handler.distributeNodes();
+
+    expect(map.history.save).not.toHaveBeenCalled();
+  });
+});

--- a/teammapper-frontend/mmp/src/map/handlers/events.ts
+++ b/teammapper-frontend/mmp/src/map/handlers/events.ts
@@ -68,4 +68,5 @@ export enum Event {
   nodeCreate = 'mmp-node-create',
   nodePaste = 'mmp-node-paste',
   nodeRemove = 'mmp-node-remove',
+  distribute = 'mmp-distribute',
 }

--- a/teammapper-frontend/mmp/src/map/handlers/nodes.ts
+++ b/teammapper-frontend/mmp/src/map/handlers/nodes.ts
@@ -16,7 +16,7 @@ import { Event } from './events';
 import Log from '../../utils/log';
 import Utils from '../../utils/utils';
 import { MapSnapshot } from './history';
-import { computeMapLayout } from './layout';
+import { computeMapLayout, LayoutInputNode } from './layout';
 import { NODE_HORIZONTAL_SPACING } from './node-geometry';
 
 const NODE_VERTICAL_SIBLING_OFFSET = 60; // The y-axis spacing between sibling nodes
@@ -835,6 +835,66 @@ export default class Nodes {
       return node;
     });
   };
+
+  /**
+   * Recompute every node's coordinates from the tree structure and the node
+   * sizes, discarding manual positioning. One mmp history entry covers the
+   * whole rewrite; the undo the user actually sees comes from the Y.Doc
+   * transaction that the distribute event triggers.
+   */
+  public distributeNodes = (notifyWithEvent = true) => {
+    const layout = computeMapLayout(this.toLayoutInput());
+    if (layout.size === 0) return;
+
+    for (const [id, coordinates] of layout) {
+      this.moveNodeTo(id, coordinates);
+    }
+
+    // Redrawing the branches costs a full selection pass, so it happens once
+    // here rather than once per node as the single-node move path does.
+    this.redrawBranches();
+    this.map.draw.update();
+    this.map.history.save();
+
+    if (notifyWithEvent) {
+      this.map.events.call(Event.distribute);
+    }
+  };
+
+  /** Move one node, leaving the branch redraw to the caller. */
+  private moveNodeTo(id: string, coordinates: Coordinates): void {
+    const node = this.nodes.get(id);
+    if (!node) return;
+
+    node.coordinates = { x: coordinates.x, y: coordinates.y };
+    node.dom?.setAttribute(
+      'transform',
+      'translate(' + [coordinates.x, coordinates.y] + ')'
+    );
+  }
+
+  private redrawBranches(): void {
+    d3.selectAll('.' + this.map.id + '_branch').attr('d', (node: Node) => {
+      // A detached node has no parent and so no branch to draw. Returning
+      // null makes d3 drop the attribute, as the other redraw paths do.
+      const branch = this.map.draw.drawBranch(node);
+
+      return branch ? branch.toString() : null;
+    });
+  }
+
+  private toLayoutInput(): LayoutInputNode[] {
+    return Array.from(this.nodes.values()).map(node => ({
+      id: node.id,
+      parent: node.parent ? node.parent.id : '',
+      isRoot: node.isRoot,
+      detached: node.detached,
+      name: node.name,
+      font: node.font,
+      coordinates: node.coordinates,
+      dimensions: node.dimensions,
+    }));
+  }
 
   /**
    * Return the lower node of a list of nodes.

--- a/teammapper-frontend/mmp/src/map/map.ts
+++ b/teammapper-frontend/mmp/src/map/map.ts
@@ -92,6 +92,7 @@ export default class MmpMap {
       copyNode: this.copyPaste.copy,
       cutNode: this.copyPaste.cut,
       applyCoordinatesToMapSnapshot: this.nodes.applyCoordinatesToMapSnapshot,
+      distributeNodes: this.nodes.distributeNodes,
       deselectNode: this.nodes.deselectNode,
       getSelectedNode: this.nodes.getSelectedNode,
       editNode: this.nodes.editNode,
@@ -136,6 +137,7 @@ export interface MmpInstance {
   copyNode: (id: string) => void;
   cutNode: (id: string) => void;
   applyCoordinatesToMapSnapshot: (mapSnapshot: MapSnapshot) => MapSnapshot;
+  distributeNodes: (notifyWithEvent?: boolean) => void;
   deselectNode: () => void;
   getSelectedNode: () => Node;
   editNode: () => void;

--- a/teammapper-frontend/src/app/core/services/map-sync/yjs-sync.service.spec.ts
+++ b/teammapper-frontend/src/app/core/services/map-sync/yjs-sync.service.spec.ts
@@ -5,6 +5,8 @@ import { ToastrService } from 'ngx-toastr';
 import { HttpService } from '../../http/http.service';
 import { MapSyncContext } from './map-sync-context';
 import { YjsSyncService } from './yjs-sync.service';
+import * as Y from 'yjs';
+import { ExportNodeProperties } from '@mmp/map/types';
 
 function createMockContext(): MapSyncContext {
   return {
@@ -38,10 +40,13 @@ function createMockMmpService(): jest.Mocked<MmpService> {
   } as unknown as jest.Mocked<MmpService>;
 }
 
-function createService(): YjsSyncService {
+function createService(
+  mmpService: jest.Mocked<MmpService> = createMockMmpService(),
+  context: MapSyncContext = createMockContext()
+): YjsSyncService {
   return new YjsSyncService(
-    createMockContext(),
-    createMockMmpService(),
+    context,
+    mmpService,
     {} as SettingsService,
     {} as UtilsService,
     {} as ToastrService,
@@ -51,7 +56,15 @@ function createService(): YjsSyncService {
 
 interface YjsSyncInternals {
   yjsWritable: boolean;
-  yDoc: unknown;
+  yjsSynced: boolean;
+  yDoc: Y.Doc;
+  handleTopLevelNodeChanges: (
+    event: unknown,
+    nodesMap: Y.Map<Y.Map<unknown>>
+  ) => void;
+  showImportToast: () => Promise<void>;
+  loadMapFromYDoc: () => void;
+  initUndoManager: () => void;
 }
 
 function internals(service: YjsSyncService): YjsSyncInternals {
@@ -109,6 +122,151 @@ describe('YjsSyncService', () => {
       service.initMap('test-uuid');
 
       expect(internals(service).yjsWritable).toBe(true);
+    });
+  });
+
+  describe('distributing nodes', () => {
+    type Handlers = Record<string, (payload?: unknown) => void>;
+
+    const snapshot = [
+      { id: 'root', parent: '', isRoot: true },
+      { id: 'child', parent: 'root', isRoot: false },
+    ] as ExportNodeProperties[];
+
+    let handlers: Handlers;
+    let service: YjsSyncService;
+    let context: MapSyncContext;
+
+    function capturingMmpService(): jest.Mocked<MmpService> {
+      return {
+        on: jest.fn((event: string) => ({
+          subscribe: (callback: (payload?: unknown) => void) => {
+            handlers[event] = callback;
+            return { unsubscribe: jest.fn() };
+          },
+        })),
+        selectNode: jest.fn(),
+        existNode: jest.fn().mockReturnValue(true),
+        exportAsJSON: jest.fn().mockReturnValue(snapshot),
+      } as unknown as jest.Mocked<MmpService>;
+    }
+
+    beforeEach(() => {
+      handlers = {};
+      context = createMockContext();
+      service = createService(capturingMmpService(), context);
+      service.initMap('test-uuid');
+      internals(service).yjsSynced = true;
+      // Normally created by handleFirstSync, which needs a live websocket.
+      internals(service).initUndoManager();
+    });
+
+    afterEach(() => {
+      service.destroy();
+    });
+
+    it('subscribes to the mmp distribute event', () => {
+      expect(Object.keys(handlers)).toContain('distribute');
+    });
+
+    it('writes every node to the doc when a distribute happens', () => {
+      handlers['distribute']();
+
+      const nodesMap = internals(service).yDoc.getMap('nodes');
+      expect(Array.from(nodesMap.keys()).sort()).toEqual(['child', 'root']);
+    });
+
+    it('refreshes the cached map so it does not keep the old coordinates', () => {
+      handlers['distribute']();
+
+      expect(context.updateAttachedMap).toHaveBeenCalled();
+    });
+
+    it('records the replacement as a distribute so peers can identify it', () => {
+      handlers['distribute']();
+
+      expect(
+        internals(service).yDoc.getMap('meta').get('lastFullMapOperation')
+      ).toBe('distribute');
+    });
+
+    it('still records an import as an import', () => {
+      handlers['create']();
+
+      expect(
+        internals(service).yDoc.getMap('meta').get('lastFullMapOperation')
+      ).toBe('import');
+    });
+
+    it('makes a distribute undoable', () => {
+      const doc = internals(service).yDoc;
+      const nodesMap = doc.getMap('nodes') as Y.Map<Y.Map<unknown>>;
+      // Seed as a local edit so the undo manager has a state to return to.
+      doc.transact(() => {
+        const yNode = new Y.Map<unknown>();
+        nodesMap.set('root', yNode);
+        yNode.set('id', 'root');
+        yNode.set('isRoot', true);
+        yNode.set('coordinates', { x: 5, y: 5 });
+      }, 'local');
+
+      handlers['distribute']();
+      service.undo();
+
+      expect(nodesMap.get('root')?.get('coordinates')).toEqual({ x: 5, y: 5 });
+    });
+
+    describe('on a receiving client', () => {
+      let nodesMap: Y.Map<Y.Map<unknown>>;
+      let importToast: jest.SpyInstance;
+
+      beforeEach(() => {
+        const doc = internals(service).yDoc;
+        nodesMap = doc.getMap('nodes') as Y.Map<Y.Map<unknown>>;
+        const yNode = new Y.Map<unknown>();
+        nodesMap.set('root', yNode);
+        yNode.set('isRoot', true);
+
+        importToast = jest
+          .spyOn(internals(service), 'showImportToast')
+          .mockResolvedValue(undefined);
+        jest
+          .spyOn(internals(service), 'loadMapFromYDoc')
+          .mockImplementation(() => undefined);
+      });
+
+      function replacementEvent(): unknown {
+        return {
+          changes: { keys: new Map([['root', { action: 'add' }]]) },
+          keysChanged: new Set(['root']),
+        };
+      }
+
+      it('does not show the import toast for a redistribution', () => {
+        internals(service)
+          .yDoc.getMap('meta')
+          .set('lastFullMapOperation', 'distribute');
+
+        internals(service).handleTopLevelNodeChanges(
+          replacementEvent(),
+          nodesMap
+        );
+
+        expect(importToast).not.toHaveBeenCalled();
+      });
+
+      it('still shows the import toast for an actual import', () => {
+        internals(service)
+          .yDoc.getMap('meta')
+          .set('lastFullMapOperation', 'import');
+
+        internals(service).handleTopLevelNodeChanges(
+          replacementEvent(),
+          nodesMap
+        );
+
+        expect(importToast).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/teammapper-frontend/src/app/core/services/map-sync/yjs-sync.service.ts
+++ b/teammapper-frontend/src/app/core/services/map-sync/yjs-sync.service.ts
@@ -32,6 +32,13 @@ import {
 
 const WS_CLOSE_MAP_DELETED = 4001;
 
+/**
+ * Which operation caused a full-map replacement. Recorded in the doc because
+ * Yjs transaction origins are local and never reach the other clients.
+ */
+type FullMapOperation = 'import' | 'distribute';
+const LAST_FULL_MAP_OPERATION = 'lastFullMapOperation';
+
 export class YjsSyncService {
   private yDoc: Y.Doc | null = null;
   private wsProvider: WebsocketProvider | null = null;
@@ -141,7 +148,9 @@ export class YjsSyncService {
   private initUndoManager(): void {
     const nodesMap = this.yDoc.getMap('nodes');
     this.yUndoManager = new Y.UndoManager(nodesMap, {
-      trackedOrigins: new Set(['local']),
+      // A distribute is tracked so one press is one undo. An import is not:
+      // loading a different map over this one is not an editing step.
+      trackedOrigins: new Set(['local', 'distribute']),
     });
     this.setupUndoManagerListeners();
   }
@@ -252,6 +261,7 @@ export class YjsSyncService {
   private createListeners(): void {
     this.unsubscribeListeners();
     this.setupCreateHandler();
+    this.setupDistributeHandler();
     this.setupSelectionHandlers();
     this.setupNodeUpdateHandler();
     this.setupNodeCreateHandler();
@@ -265,8 +275,24 @@ export class YjsSyncService {
         this.ctx.setAttachedNode(this.mmpService.selectNode());
         this.ctx.updateAttachedMap();
         if (this.yjsSynced) {
-          this.writeImportToYDoc();
+          this.writeFullMapToYDoc('import');
         }
+      })
+    );
+  }
+
+  /**
+   * A redistribution rewrites every node's coordinates at once, so it goes out
+   * as a full-map replacement rather than as one update per node.
+   */
+  private setupDistributeHandler(): void {
+    this.yjsSubscriptions.push(
+      this.mmpService.on('distribute').subscribe(() => {
+        if (!this.yDoc) return;
+        if (this.yjsSynced) {
+          this.writeFullMapToYDoc('distribute');
+        }
+        this.ctx.updateAttachedMap();
       })
     );
   }
@@ -391,14 +417,25 @@ export class YjsSyncService {
     }, 'local');
   }
 
-  private writeImportToYDoc(): void {
+  private writeFullMapToYDoc(operation: FullMapOperation): void {
     const snapshot = this.mmpService.exportAsJSON();
     const nodesMap = this.yDoc.getMap('nodes') as Y.Map<Y.Map<unknown>>;
     const sorted = sortParentFirst(snapshot);
 
+    // Without this, Yjs merges the replacement with whatever the user did in
+    // the preceding half second and one undo would revert both.
+    this.yUndoManager?.stopCapturing();
+
     this.yDoc.transact(() => {
+      this.yDoc.getMap('meta').set(LAST_FULL_MAP_OPERATION, operation);
       this.clearAndRepopulateNodes(nodesMap, sorted);
-    }, 'import');
+    }, operation);
+  }
+
+  private lastFullMapOperation(): FullMapOperation {
+    const recorded = this.yDoc.getMap('meta').get(LAST_FULL_MAP_OPERATION);
+
+    return recorded === 'distribute' ? 'distribute' : 'import';
   }
 
   private clearAndRepopulateNodes(
@@ -469,7 +506,11 @@ export class YjsSyncService {
 
     if (this.isFullMapReplacement(mapEvent, nodesMap)) {
       this.loadMapFromYDoc();
-      this.showImportToast();
+      // A redistribution replaces the map the way an import does, but must not
+      // be announced as one.
+      if (this.lastFullMapOperation() !== 'distribute') {
+        this.showImportToast();
+      }
       return;
     }
 

--- a/teammapper-frontend/src/app/core/services/mmp/mmp.service.spec.ts
+++ b/teammapper-frontend/src/app/core/services/mmp/mmp.service.spec.ts
@@ -62,6 +62,7 @@ describe('MmpService', () => {
       cutNode: jest.fn(),
       pasteNode: jest.fn(),
       toggleBranchVisibility: jest.fn(),
+      distributeNodes: jest.fn(),
       nodeChildren: jest.fn(),
       exportSelectedNode: jest.fn(),
       undo: jest.fn(),
@@ -263,6 +264,18 @@ describe('MmpService', () => {
         expect(result.success).toBe(true);
         expect(downloadFileSpy).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('distributeNodes', () => {
+    beforeEach(async () => {
+      await service.create('test-id', document.createElement('div'));
+    });
+
+    it('should delegate distributing the nodes to the mmp instance', () => {
+      service.distributeNodes();
+
+      expect(mockMap.instance.distributeNodes).toHaveBeenCalled();
     });
   });
 });

--- a/teammapper-frontend/src/app/core/services/mmp/mmp.service.ts
+++ b/teammapper-frontend/src/app/core/services/mmp/mmp.service.ts
@@ -474,6 +474,13 @@ export class MmpService implements OnDestroy {
   }
 
   /**
+   * Recompute every node's position from the tree, discarding manual placement.
+   */
+  public distributeNodes() {
+    this.currentMap.instance.distributeNodes();
+  }
+
+  /**
    * Return the children of the current node.
    */
   public nodeChildren(): ExportNodeProperties[] {

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
@@ -168,6 +168,15 @@
     mat-icon-button>
     <mat-icon>{{ hasHiddenNodes ? 'visibility_off' : 'visibility' }}</mat-icon>
   </button>
+  <button
+    id="distribute-nodes-button"
+    (click)="mmpService.distributeNodes()"
+    [title]="'TOOLTIPS.DISTRIBUTE_NODES' | translate"
+    [disabled]="editDisabled"
+    color="primary"
+    mat-icon-button>
+    <mat-icon>account_tree</mat-icon>
+  </button>
 
   <div class="vertical-line">
     <div></div>

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.spec.ts
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.spec.ts
@@ -32,6 +32,7 @@ class MmpServiceStub {
   addNode = jest.fn();
   removeNodeLink = jest.fn();
   toggleBranchVisibility = jest.fn();
+  distributeNodes = jest.fn();
   addNodeImage = jest.fn();
   importMap = jest.fn();
 }
@@ -344,6 +345,26 @@ describe('ToolbarComponent', () => {
       const undoButton =
         ctx.fixture.nativeElement.querySelector('#undo-button');
       expect(undoButton.disabled).toBe(true);
+    });
+  });
+
+  describe('distribute nodes', () => {
+    it('should render a button for distributing the nodes evenly', () => {
+      const button = ctx.fixture.nativeElement.querySelector(
+        '#distribute-nodes-button'
+      );
+
+      expect(button).not.toBeNull();
+    });
+
+    it('should distribute the nodes when the button is clicked', () => {
+      const button = ctx.fixture.nativeElement.querySelector(
+        '#distribute-nodes-button'
+      );
+
+      button.click();
+
+      expect(ctx.mmpService.distributeNodes).toHaveBeenCalled();
     });
   });
 });

--- a/teammapper-frontend/src/assets/i18n/de.json
+++ b/teammapper-frontend/src/assets/i18n/de.json
@@ -36,6 +36,7 @@
     "CUT_NODE": "Aktuellen Knoten ausschneiden",
     "PASTE_NODE": "Kopierten Knoten einfügen",
     "HIDE_CHILD_NODES": "Untergeordnete Knoten ausblenden",
+    "DISTRIBUTE_NODES": "Alle Knoten gleichmäßig verteilen",
     "MOVE_NODE_TO_THE_LEFT": "Knoten nach links verschieben",
     "MOVE_NODE_TO_THE_RIGHT": "Knoten nach rechts verschieben",
     "MOVE_NODE_DOWN": "Knoten nach unten verschieben",

--- a/teammapper-frontend/src/assets/i18n/en.json
+++ b/teammapper-frontend/src/assets/i18n/en.json
@@ -36,6 +36,7 @@
     "CUT_NODE": "Cuts the current node",
     "PASTE_NODE": "Paste the copied node",
     "HIDE_CHILD_NODES": "Hide child nodes",
+    "DISTRIBUTE_NODES": "Distribute all nodes evenly",
     "MOVE_NODE_TO_THE_LEFT": "Moves the node to the left",
     "MOVE_NODE_TO_THE_RIGHT": "Moves the node to the right",
     "MOVE_NODE_DOWN": "Moves the node down",

--- a/teammapper-frontend/src/assets/i18n/es.json
+++ b/teammapper-frontend/src/assets/i18n/es.json
@@ -36,6 +36,7 @@
     "CUT_NODE": "Cortar el nodo actual",
     "PASTE_NODE": "Pegar el nodo copiado",
     "HIDE_CHILD_NODES": "Ocultar nodos hijos",
+    "DISTRIBUTE_NODES": "Distribuir todos los nodos uniformemente",
     "MOVE_NODE_TO_THE_LEFT": "Mover el nodo a la izquierda",
     "MOVE_NODE_TO_THE_RIGHT": "Mover el nodo a la derecha",
     "MOVE_NODE_DOWN": "Mover el nodo hacia abajo",

--- a/teammapper-frontend/src/assets/i18n/fr.json
+++ b/teammapper-frontend/src/assets/i18n/fr.json
@@ -36,6 +36,7 @@
     "CUT_NODE": "Coupe le nœud actuel",
     "PASTE_NODE": "Collez le noeud copié",
     "HIDE_CHILD_NODES": "Masquer les nœuds enfants",
+    "DISTRIBUTE_NODES": "Répartir tous les nœuds uniformément",
     "MOVE_NODE_TO_THE_LEFT": "Déplace le nœud vers la gauche",
     "MOVE_NODE_TO_THE_RIGHT": "Déplace le noeud vers la droite",
     "MOVE_NODE_DOWN": "Déplace le nœud vers le bas",

--- a/teammapper-frontend/src/assets/i18n/it.json
+++ b/teammapper-frontend/src/assets/i18n/it.json
@@ -36,6 +36,7 @@
     "CUT_NODE": "Taglia nodo selezionato",
     "PASTE_NODE": "Incolla nodo copiato",
     "HIDE_CHILD_NODES": "Nascondere nodi figli",
+    "DISTRIBUTE_NODES": "Distribuire tutti i nodi uniformemente",
     "MOVE_NODE_TO_THE_LEFT": "Muovi nodo a sinistra",
     "MOVE_NODE_TO_THE_RIGHT": "Muovi nodo a destra",
     "MOVE_NODE_DOWN": "Muovi nodo in basso",

--- a/teammapper-frontend/src/assets/i18n/ja.json
+++ b/teammapper-frontend/src/assets/i18n/ja.json
@@ -36,6 +36,7 @@
     "CUT_NODE": "ノードを切り取り",
     "PASTE_NODE": "ノードを貼り付け",
     "HIDE_CHILD_NODES": "子ノードを非表示",
+    "DISTRIBUTE_NODES": "すべてのノードを均等に配置",
     "MOVE_NODE_TO_THE_LEFT": "ノードを左へ移動",
     "MOVE_NODE_TO_THE_RIGHT": "ノードを右へ移動",
     "MOVE_NODE_DOWN": "ノードを下へ移動",

--- a/teammapper-frontend/src/assets/i18n/pt-br.json
+++ b/teammapper-frontend/src/assets/i18n/pt-br.json
@@ -36,6 +36,7 @@
     "CUT_NODE": "Recortar o nó atual",
     "PASTE_NODE": "Colar o nó copiado",
     "HIDE_CHILD_NODES": "Ocultar nós filhos",
+    "DISTRIBUTE_NODES": "Distribuir todos os nós uniformemente",
     "MOVE_NODE_TO_THE_LEFT": "Mover o nó para a esquerda",
     "MOVE_NODE_TO_THE_RIGHT": "Mover o nó para a direita",
     "MOVE_NODE_DOWN": "Mover o nó para baixo",

--- a/teammapper-frontend/src/assets/i18n/zh-cn.json
+++ b/teammapper-frontend/src/assets/i18n/zh-cn.json
@@ -36,6 +36,7 @@
     "CUT_NODE": "剪切节点",
     "PASTE_NODE": "粘贴节点",
     "HIDE_CHILD_NODES": "隐藏子节点",
+    "DISTRIBUTE_NODES": "均匀分布所有节点",
     "MOVE_NODE_TO_THE_LEFT": "左移节点",
     "MOVE_NODE_TO_THE_RIGHT": "右移节点",
     "MOVE_NODE_DOWN": "下移节点",

--- a/teammapper-frontend/src/assets/i18n/zh-tw.json
+++ b/teammapper-frontend/src/assets/i18n/zh-tw.json
@@ -36,6 +36,7 @@
     "CUT_NODE": "剪下選取的節點",
     "PASTE_NODE": "貼上已複製的節點",
     "HIDE_CHILD_NODES": "Hide child nodes",
+    "DISTRIBUTE_NODES": "均勻分佈所有節點",
     "MOVE_NODE_TO_THE_LEFT": "將節點向左移動",
     "MOVE_NODE_TO_THE_RIGHT": "將節點向右移動",
     "MOVE_NODE_DOWN": "將節點向下移動",


### PR DESCRIPTION
Recomputes every node position from the tree, discarding manual placement. The rewrite syncs as a full-map replacement, tracked as a single undo step and without the toast an import raises.